### PR TITLE
Fix automatic binding generation

### DIFF
--- a/res/wrap.jl
+++ b/res/wrap.jl
@@ -9,37 +9,23 @@ isdir(header_dir) || error("$header_dir does not exist")
 
 const FLUX_INCLUDE = normpath(header_dir)
 
-# Fails with `include/flux/core/barrier.h:24:1: error: unknown type name 'flux_future_t'`
-# as far as I can tell `barrier.h` is not including `future.h`
-# headers = ["flux/core.h"]
-# core_headers = readdir(joinpath(FLUX_INCLUDE, "flux/core"))
-# filter!(h->endswith(h, ".h"), core_headers)
-# core_headers = map(h->joinpath("flux/core", h), core_headers)
-# append!(headers, core_headers)
-
-# Flux comes with preprocessed bindings for Python
-# they still come with some need for fixups
-#
-# Add: 
-#include <stdint.h>
-#include <stdbool.h>
-#include <stddef.h>
-#include <stdarg.h>
-#include <unistd.h>
-#include <stdio.h>
-#
-# Comment out: 
-# `extern "Python"`
-headers = ["flux/_binding/_core_preproc.h"]
-
+headers = ["flux/core.h"]
 FLUX_HEADERS = map(h->joinpath(FLUX_INCLUDE,h), headers)
+
+# To inlude all of the headers included by `core.h`
+function wrapped(root, current)
+  if dirname(current) == joinpath(FLUX_INCLUDE, "flux", "core")
+    return true
+  end
+  return root == current
+end
 
 wc = init(; headers = FLUX_HEADERS,
             output_file = "libflux_h.jl",
             common_file = "libflux_common.jl",
             clang_includes = [FLUX_INCLUDE, CLANG_INCLUDE],
             clang_args = ["-I", FLUX_INCLUDE],
-            header_wrapped = (root, current)->root == current,
+            header_wrapped = wrapped,
             header_library = x->"libflux_core",
             )
 

--- a/src/api/libflux_common.jl
+++ b/src/api/libflux_common.jl
@@ -1,6 +1,40 @@
 # Automatically generated using Clang.jl
 
 
+# Skipping MacroDefinition: FLUX_MATCH_ANY flux_match_init ( FLUX_MSGTYPE_ANY , FLUX_MATCHTAG_NONE , NULL \#
+)
+# Skipping MacroDefinition: FLUX_MATCH_EVENT flux_match_init ( FLUX_MSGTYPE_EVENT , FLUX_MATCHTAG_NONE , NULL \#
+)
+# Skipping MacroDefinition: FLUX_MATCH_REQUEST flux_match_init ( FLUX_MSGTYPE_REQUEST , FLUX_MATCHTAG_NONE , NULL \#
+)
+# Skipping MacroDefinition: FLUX_MATCH_RESPONSE flux_match_init ( FLUX_MSGTYPE_RESPONSE , FLUX_MATCHTAG_NONE , NULL \#
+)
+
+const FLUX_OPT_TESTING_USERID = "flux::testing_userid"
+const FLUX_OPT_TESTING_ROLEMASK = "flux::testing_rolemask"
+
+# Skipping MacroDefinition: FLUX_FATAL ( h ) do { flux_fatal_error ( ( h ) , __FUNCTION__ , ( strerror ( errno ) ) ) ; \
+#} while ( 0 )
+# Skipping MacroDefinition: FLUX_MSGHANDLER_TABLE_END { 0 , NULL , NULL , 0 }
+
+const FLUX_MAX_LOGBUF = 2048
+
+# Skipping MacroDefinition: FLUX_LOG_ERROR ( h ) ( void ) flux_log_error ( ( h ) , "%s::%d[%s]" , __FILE__ , __LINE__ , __FUNCTION__ )
+# Skipping MacroDefinition: future_strerror ( __f , __errno ) ( flux_future_has_error ( ( __f ) ) ? flux_future_error_string ( ( __f ) ) : flux_strerror ( ( __errno ) ) )
+# Skipping MacroDefinition: MOD_NAME ( x ) const char * mod_name = x
+
+const FLUX_CORE_VERSION_STRING = "0.23.0"
+const FLUX_CORE_VERSION_MAJOR = 0
+const FLUX_CORE_VERSION_MINOR = 23
+const FLUX_CORE_VERSION_PATCH = 0
+
+# Skipping MacroDefinition: FLUX_CORE_VERSION_HEX ( ( FLUX_CORE_VERSION_MAJOR << 16 ) | ( FLUX_CORE_VERSION_MINOR << 8 ) | ( FLUX_CORE_VERSION_PATCH << 0 ) )
+
+const KVS_PRIMARY_NAMESPACE = "primary"
+const FLUX_JOB_NR_STATES = 7
+
+# Skipping MacroDefinition: flux_subprocess_destroy ( x ) flux_subprocess_unref ( x )
+
 const flux_free_f = Ptr{Cvoid}
 const flux_msg = Cvoid
 const flux_msg_t = flux_msg
@@ -138,7 +172,44 @@ end
     FLUX_KVS_WATCH_APPEND = 256
 end
 
+@cenum job_submit_flags::UInt32 begin
+    FLUX_JOB_PRE_SIGNED = 1
+    FLUX_JOB_DEBUG = 2
+    FLUX_JOB_WAITABLE = 4
+end
 
+@cenum job_urgency::UInt32 begin
+    FLUX_JOB_URGENCY_MIN = 0
+    FLUX_JOB_URGENCY_HOLD = 0
+    FLUX_JOB_URGENCY_DEFAULT = 16
+    FLUX_JOB_URGENCY_MAX = 31
+    FLUX_JOB_URGENCY_EXPEDITE = 31
+end
+
+@cenum job_queue_priority::UInt32 begin
+    FLUX_JOB_PRIORITY_MIN = 0
+    FLUX_JOB_PRIORITY_MAX = 4294967295
+end
+
+@cenum flux_job_state_t::UInt32 begin
+    FLUX_JOB_STATE_NEW = 1
+    FLUX_JOB_STATE_DEPEND = 2
+    FLUX_JOB_STATE_PRIORITY = 4
+    FLUX_JOB_STATE_SCHED = 8
+    FLUX_JOB_STATE_RUN = 16
+    FLUX_JOB_STATE_CLEANUP = 32
+    FLUX_JOB_STATE_INACTIVE = 64
+end
+
+@cenum flux_job_result_t::UInt32 begin
+    FLUX_JOB_RESULT_COMPLETED = 1
+    FLUX_JOB_RESULT_FAILED = 2
+    FLUX_JOB_RESULT_CANCELED = 4
+    FLUX_JOB_RESULT_TIMEOUT = 8
+end
+
+
+const flux_jobid_t = UInt64
 const flux_command = Cvoid
 const flux_cmd_t = flux_command
 const flux_subprocess = Cvoid
@@ -174,34 +245,3 @@ struct flux_subprocess_hooks_t
     post_fork::flux_subprocess_hook_f
     post_fork_arg::Ptr{Cvoid}
 end
-
-@cenum job_submit_flags::UInt32 begin
-    FLUX_JOB_PRE_SIGNED = 1
-    FLUX_JOB_DEBUG = 2
-    FLUX_JOB_WAITABLE = 4
-end
-
-@cenum job_priority::UInt32 begin
-    FLUX_JOB_PRIORITY_MIN = 0
-    FLUX_JOB_PRIORITY_DEFAULT = 16
-    FLUX_JOB_PRIORITY_MAX = 31
-end
-
-@cenum flux_job_state_t::UInt32 begin
-    FLUX_JOB_NEW = 1
-    FLUX_JOB_DEPEND = 2
-    FLUX_JOB_SCHED = 4
-    FLUX_JOB_RUN = 8
-    FLUX_JOB_CLEANUP = 16
-    FLUX_JOB_INACTIVE = 32
-end
-
-@cenum flux_job_result_t::UInt32 begin
-    FLUX_JOB_RESULT_COMPLETED = 1
-    FLUX_JOB_RESULT_FAILED = 2
-    FLUX_JOB_RESULT_CANCELLED = 4
-    FLUX_JOB_RESULT_TIMEOUT = 8
-end
-
-
-const flux_jobid_t = UInt64

--- a/src/api/libflux_common.jl
+++ b/src/api/libflux_common.jl
@@ -2,13 +2,9 @@
 
 
 # Skipping MacroDefinition: FLUX_MATCH_ANY flux_match_init ( FLUX_MSGTYPE_ANY , FLUX_MATCHTAG_NONE , NULL \#
-)
 # Skipping MacroDefinition: FLUX_MATCH_EVENT flux_match_init ( FLUX_MSGTYPE_EVENT , FLUX_MATCHTAG_NONE , NULL \#
-)
 # Skipping MacroDefinition: FLUX_MATCH_REQUEST flux_match_init ( FLUX_MSGTYPE_REQUEST , FLUX_MATCHTAG_NONE , NULL \#
-)
 # Skipping MacroDefinition: FLUX_MATCH_RESPONSE flux_match_init ( FLUX_MSGTYPE_RESPONSE , FLUX_MATCHTAG_NONE , NULL \#
-)
 
 const FLUX_OPT_TESTING_USERID = "flux::testing_userid"
 const FLUX_OPT_TESTING_ROLEMASK = "flux::testing_rolemask"

--- a/src/api/libflux_h.jl
+++ b/src/api/libflux_h.jl
@@ -622,9 +622,9 @@ function flux_stat_watcher_create(r, path, interval, cb, arg)
     ccall((:flux_stat_watcher_create, libflux_core), Ptr{flux_watcher_t}, (Ptr{flux_reactor_t}, Cstring, Cdouble, flux_watcher_f, Ptr{Cvoid}), r, path, interval, cb, arg)
 end
 
-function flux_stat_watcher_get_rstat(w, stat, prev)
-    ccall((:flux_stat_watcher_get_rstat, libflux_core), Cvoid, (Ptr{flux_watcher_t}, Ptr{stat}, Ptr{stat}), w, stat, prev)
-end
+#function flux_stat_watcher_get_rstat(w, stat, prev)
+#    ccall((:flux_stat_watcher_get_rstat, libflux_core), Cvoid, (Ptr{flux_watcher_t}, Ptr{stat}, Ptr{stat}), w, stat, prev)
+#end
 
 function flux_watcher_create(r, data_size, ops, fn, arg)
     ccall((:flux_watcher_create, libflux_core), Ptr{flux_watcher_t}, (Ptr{flux_reactor_t}, Csize_t, Ptr{flux_watcher_ops}, flux_watcher_f, Ptr{Cvoid}), r, data_size, ops, fn, arg)
@@ -942,13 +942,13 @@ function flux_event_publish_get_seq(f, seq)
     ccall((:flux_event_publish_get_seq, libflux_core), Cint, (Ptr{flux_future_t}, Ptr{Cint}), f, seq)
 end
 
-function flux_modname(filename, cb, arg)
-    ccall((:flux_modname, libflux_core), Cstring, (Cstring, Ptr{flux_moderr_f}, Ptr{Cvoid}), filename, cb, arg)
-end
+# function flux_modname(filename, cb, arg)
+#     ccall((:flux_modname, libflux_core), Cstring, (Cstring, Ptr{flux_moderr_f}, Ptr{Cvoid}), filename, cb, arg)
+# end
 
-function flux_modfind(searchpath, modname, cb, arg)
-    ccall((:flux_modfind, libflux_core), Cstring, (Cstring, Cstring, Ptr{flux_moderr_f}, Ptr{Cvoid}), searchpath, modname, cb, arg)
-end
+# function flux_modfind(searchpath, modname, cb, arg)
+#     ccall((:flux_modfind, libflux_core), Cstring, (Cstring, Cstring, Ptr{flux_moderr_f}, Ptr{Cvoid}), searchpath, modname, cb, arg)
+# end
 
 function flux_module_debug_test(h, flag, clear)
     ccall((:flux_module_debug_test, libflux_core), Bool, (Ptr{flux_t}, Cint, Bool), h, flag, clear)

--- a/src/api/libflux_h.jl
+++ b/src/api/libflux_h.jl
@@ -1,4 +1,4 @@
-# Julia wrapper for header: _core_preproc.h
+# Julia wrapper for header: core.h
 # Automatically generated using Clang.jl
 
 
@@ -56,6 +56,10 @@ end
 
 function flux_msg_sendzsock(dest, msg)
     ccall((:flux_msg_sendzsock, libflux_core), Cint, (Ptr{Cvoid}, Ptr{flux_msg_t}), dest, msg)
+end
+
+function flux_msg_sendzsock_ex(dest, msg, nonblock)
+    ccall((:flux_msg_sendzsock_ex, libflux_core), Cint, (Ptr{Cvoid}, Ptr{flux_msg_t}, Bool), dest, msg, nonblock)
 end
 
 function flux_msg_recvzsock(dest)
@@ -618,8 +622,8 @@ function flux_stat_watcher_create(r, path, interval, cb, arg)
     ccall((:flux_stat_watcher_create, libflux_core), Ptr{flux_watcher_t}, (Ptr{flux_reactor_t}, Cstring, Cdouble, flux_watcher_f, Ptr{Cvoid}), r, path, interval, cb, arg)
 end
 
-function flux_stat_watcher_get_rstat(w, curr, prev)
-    ccall((:flux_stat_watcher_get_rstat, libflux_core), Cvoid, (Ptr{flux_watcher_t}, Ptr{stat}, Ptr{stat}), w, curr, prev)
+function flux_stat_watcher_get_rstat(w, stat, prev)
+    ccall((:flux_stat_watcher_get_rstat, libflux_core), Cvoid, (Ptr{flux_watcher_t}, Ptr{stat}, Ptr{stat}), w, stat, prev)
 end
 
 function flux_watcher_create(r, data_size, ops, fn, arg)
@@ -752,14 +756,6 @@ end
 
 function flux_log_set_redirect(h, fun, arg)
     ccall((:flux_log_set_redirect, libflux_core), Cvoid, (Ptr{flux_t}, flux_log_f, Ptr{Cvoid}), h, fun, arg)
-end
-
-function flux_dmesg(h, flags, fun, arg)
-    ccall((:flux_dmesg, libflux_core), Cint, (Ptr{flux_t}, Cint, flux_log_f, Ptr{Cvoid}), h, flags, fun, arg)
-end
-
-function flux_log_fprint(buf, len, arg)
-    ccall((:flux_log_fprint, libflux_core), Cvoid, (Cstring, Cint, Ptr{Cvoid}), buf, len, arg)
 end
 
 function flux_strerror(errnum)
@@ -946,13 +942,13 @@ function flux_event_publish_get_seq(f, seq)
     ccall((:flux_event_publish_get_seq, libflux_core), Cint, (Ptr{flux_future_t}, Ptr{Cint}), f, seq)
 end
 
-# function flux_modname(filename, cb, arg)
-#     ccall((:flux_modname, libflux_core), Cstring, (Cstring, Ptr{flux_moderr_f}, Ptr{Cvoid}), filename, cb, arg)
-# end
+function flux_modname(filename, cb, arg)
+    ccall((:flux_modname, libflux_core), Cstring, (Cstring, Ptr{flux_moderr_f}, Ptr{Cvoid}), filename, cb, arg)
+end
 
-# function flux_modfind(searchpath, modname, cb, arg)
-#     ccall((:flux_modfind, libflux_core), Cstring, (Cstring, Cstring, Ptr{flux_moderr_f}, Ptr{Cvoid}), searchpath, modname, cb, arg)
-# end
+function flux_modfind(searchpath, modname, cb, arg)
+    ccall((:flux_modfind, libflux_core), Cstring, (Cstring, Cstring, Ptr{flux_moderr_f}, Ptr{Cvoid}), searchpath, modname, cb, arg)
+end
 
 function flux_module_debug_test(h, flag, clear)
     ccall((:flux_module_debug_test, libflux_core), Bool, (Ptr{flux_t}, Cint, Bool), h, flag, clear)
@@ -1068,6 +1064,14 @@ end
 
 function flux_plugin_destroy(p)
     ccall((:flux_plugin_destroy, libflux_core), Cvoid, (Ptr{flux_plugin_t},), p)
+end
+
+function flux_plugin_get_flags(p)
+    ccall((:flux_plugin_get_flags, libflux_core), Cint, (Ptr{flux_plugin_t},), p)
+end
+
+function flux_plugin_set_flags(p, flags)
+    ccall((:flux_plugin_set_flags, libflux_core), Cint, (Ptr{flux_plugin_t}, Cint), p, flags)
 end
 
 function flux_plugin_strerror(p)
@@ -1342,6 +1346,102 @@ function flux_kvs_dropcache(h)
     ccall((:flux_kvs_dropcache, libflux_core), Cint, (Ptr{flux_t},), h)
 end
 
+function flux_job_id_parse(s, id)
+    ccall((:flux_job_id_parse, libflux_core), Cint, (Cstring, Ptr{flux_jobid_t}), s, id)
+end
+
+function flux_job_id_encode(id, type, buf, bufsz)
+    ccall((:flux_job_id_encode, libflux_core), Cint, (flux_jobid_t, Cstring, Cstring, Csize_t), id, type, buf, bufsz)
+end
+
+function flux_job_statetostr(state, single_char)
+    ccall((:flux_job_statetostr, libflux_core), Cstring, (flux_job_state_t, Bool), state, single_char)
+end
+
+function flux_job_strtostate(s, state)
+    ccall((:flux_job_strtostate, libflux_core), Cint, (Cstring, Ptr{flux_job_state_t}), s, state)
+end
+
+function flux_job_resulttostr(result, abbrev)
+    ccall((:flux_job_resulttostr, libflux_core), Cstring, (flux_job_result_t, Bool), result, abbrev)
+end
+
+function flux_job_strtoresult(s, result)
+    ccall((:flux_job_strtoresult, libflux_core), Cint, (Cstring, Ptr{flux_job_result_t}), s, result)
+end
+
+function flux_job_submit(h, jobspec, urgency, flags)
+    ccall((:flux_job_submit, libflux_core), Ptr{flux_future_t}, (Ptr{flux_t}, Cstring, Cint, Cint), h, jobspec, urgency, flags)
+end
+
+function flux_job_submit_get_id(f, id)
+    ccall((:flux_job_submit_get_id, libflux_core), Cint, (Ptr{flux_future_t}, Ptr{flux_jobid_t}), f, id)
+end
+
+function flux_job_wait(h, id)
+    ccall((:flux_job_wait, libflux_core), Ptr{flux_future_t}, (Ptr{flux_t}, flux_jobid_t), h, id)
+end
+
+function flux_job_wait_get_status(f, success, errstr)
+    ccall((:flux_job_wait_get_status, libflux_core), Cint, (Ptr{flux_future_t}, Ptr{Bool}, Ptr{Cstring}), f, success, errstr)
+end
+
+function flux_job_wait_get_id(f, id)
+    ccall((:flux_job_wait_get_id, libflux_core), Cint, (Ptr{flux_future_t}, Ptr{flux_jobid_t}), f, id)
+end
+
+function flux_job_list(h, max_entries, json_str, userid, states)
+    ccall((:flux_job_list, libflux_core), Ptr{flux_future_t}, (Ptr{flux_t}, Cint, Cstring, UInt32, Cint), h, max_entries, json_str, userid, states)
+end
+
+function flux_job_list_inactive(h, max_entries, since, json_str)
+    ccall((:flux_job_list_inactive, libflux_core), Ptr{flux_future_t}, (Ptr{flux_t}, Cint, Cdouble, Cstring), h, max_entries, since, json_str)
+end
+
+function flux_job_list_id(h, id, json_str)
+    ccall((:flux_job_list_id, libflux_core), Ptr{flux_future_t}, (Ptr{flux_t}, flux_jobid_t, Cstring), h, id, json_str)
+end
+
+function flux_job_raise(h, id, type, severity, note)
+    ccall((:flux_job_raise, libflux_core), Ptr{flux_future_t}, (Ptr{flux_t}, flux_jobid_t, Cstring, Cint, Cstring), h, id, type, severity, note)
+end
+
+function flux_job_cancel(h, id, reason)
+    ccall((:flux_job_cancel, libflux_core), Ptr{flux_future_t}, (Ptr{flux_t}, flux_jobid_t, Cstring), h, id, reason)
+end
+
+function flux_job_kill(h, id, signum)
+    ccall((:flux_job_kill, libflux_core), Ptr{flux_future_t}, (Ptr{flux_t}, flux_jobid_t, Cint), h, id, signum)
+end
+
+function flux_job_set_urgency(h, id, urgency)
+    ccall((:flux_job_set_urgency, libflux_core), Ptr{flux_future_t}, (Ptr{flux_t}, flux_jobid_t, Cint), h, id, urgency)
+end
+
+function flux_job_kvs_key(buf, bufsz, id, key)
+    ccall((:flux_job_kvs_key, libflux_core), Cint, (Cstring, Cint, flux_jobid_t, Cstring), buf, bufsz, id, key)
+end
+
+function flux_job_kvs_guest_key(buf, bufsz, id, key)
+    ccall((:flux_job_kvs_guest_key, libflux_core), Cint, (Cstring, Cint, flux_jobid_t, Cstring), buf, bufsz, id, key)
+end
+
+function flux_job_kvs_namespace(buf, bufsz, id)
+    ccall((:flux_job_kvs_namespace, libflux_core), Cint, (Cstring, Cint, flux_jobid_t), buf, bufsz, id)
+end
+
+function flux_job_event_watch(h, id, path, flags)
+    ccall((:flux_job_event_watch, libflux_core), Ptr{flux_future_t}, (Ptr{flux_t}, flux_jobid_t, Cstring, Cint), h, id, path, flags)
+end
+
+function flux_job_event_watch_get(f, event)
+    ccall((:flux_job_event_watch_get, libflux_core), Cint, (Ptr{flux_future_t}, Ptr{Cstring}), f, event)
+end
+
+function flux_job_event_watch_cancel(f)
+    ccall((:flux_job_event_watch_cancel, libflux_core), Cint, (Ptr{flux_future_t},), f)
+end
+
 function flux_subprocess_server_start(h, prefix, local_uri, rank)
     ccall((:flux_subprocess_server_start, libflux_core), Ptr{flux_subprocess_server_t}, (Ptr{flux_t}, Cstring, Cstring, UInt32), h, prefix, local_uri, rank)
 end
@@ -1536,112 +1636,4 @@ end
 
 function flux_subprocess_aux_get(p, name)
     ccall((:flux_subprocess_aux_get, libflux_core), Ptr{Cvoid}, (Ptr{flux_subprocess_t}, Cstring), p, name)
-end
-
-function flux_job_id_parse(s, id)
-    ccall((:flux_job_id_parse, libflux_core), Cint, (Cstring, Ptr{flux_jobid_t}), s, id)
-end
-
-function flux_job_id_encode(id, type, buf, bufsz)
-    ccall((:flux_job_id_encode, libflux_core), Cint, (flux_jobid_t, Cstring, Cstring, Csize_t), id, type, buf, bufsz)
-end
-
-function flux_job_statetostr(state, single_char)
-    ccall((:flux_job_statetostr, libflux_core), Cstring, (flux_job_state_t, Bool), state, single_char)
-end
-
-function flux_job_strtostate(s, state)
-    ccall((:flux_job_strtostate, libflux_core), Cint, (Cstring, Ptr{flux_job_state_t}), s, state)
-end
-
-function flux_job_resulttostr(result, abbrev)
-    ccall((:flux_job_resulttostr, libflux_core), Cstring, (flux_job_result_t, Bool), result, abbrev)
-end
-
-function flux_job_strtoresult(s, result)
-    ccall((:flux_job_strtoresult, libflux_core), Cint, (Cstring, Ptr{flux_job_result_t}), s, result)
-end
-
-function flux_job_submit(h, jobspec, priority, flags)
-    ccall((:flux_job_submit, libflux_core), Ptr{flux_future_t}, (Ptr{flux_t}, Cstring, Cint, Cint), h, jobspec, priority, flags)
-end
-
-function flux_job_submit_get_id(f, id)
-    ccall((:flux_job_submit_get_id, libflux_core), Cint, (Ptr{flux_future_t}, Ptr{flux_jobid_t}), f, id)
-end
-
-function flux_job_wait(h, id)
-    ccall((:flux_job_wait, libflux_core), Ptr{flux_future_t}, (Ptr{flux_t}, flux_jobid_t), h, id)
-end
-
-function flux_job_wait_get_status(f, success, errstr)
-    ccall((:flux_job_wait_get_status, libflux_core), Cint, (Ptr{flux_future_t}, Ptr{Bool}, Ptr{Cstring}), f, success, errstr)
-end
-
-function flux_job_wait_get_id(f, id)
-    ccall((:flux_job_wait_get_id, libflux_core), Cint, (Ptr{flux_future_t}, Ptr{flux_jobid_t}), f, id)
-end
-
-function flux_job_list(h, max_entries, json_str, userid, states)
-    ccall((:flux_job_list, libflux_core), Ptr{flux_future_t}, (Ptr{flux_t}, Cint, Cstring, UInt32, Cint), h, max_entries, json_str, userid, states)
-end
-
-function flux_job_list_inactive(h, max_entries, since, json_str)
-    ccall((:flux_job_list_inactive, libflux_core), Ptr{flux_future_t}, (Ptr{flux_t}, Cint, Cdouble, Cstring), h, max_entries, since, json_str)
-end
-
-function flux_job_list_id(h, id, json_str)
-    ccall((:flux_job_list_id, libflux_core), Ptr{flux_future_t}, (Ptr{flux_t}, flux_jobid_t, Cstring), h, id, json_str)
-end
-
-function flux_job_raise(h, id, type, severity, note)
-    ccall((:flux_job_raise, libflux_core), Ptr{flux_future_t}, (Ptr{flux_t}, flux_jobid_t, Cstring, Cint, Cstring), h, id, type, severity, note)
-end
-
-function flux_job_cancel(h, id, reason)
-    ccall((:flux_job_cancel, libflux_core), Ptr{flux_future_t}, (Ptr{flux_t}, flux_jobid_t, Cstring), h, id, reason)
-end
-
-function flux_job_kill(h, id, signum)
-    ccall((:flux_job_kill, libflux_core), Ptr{flux_future_t}, (Ptr{flux_t}, flux_jobid_t, Cint), h, id, signum)
-end
-
-function flux_job_set_priority(h, id, priority)
-    ccall((:flux_job_set_priority, libflux_core), Ptr{flux_future_t}, (Ptr{flux_t}, flux_jobid_t, Cint), h, id, priority)
-end
-
-function flux_job_kvs_key(buf, bufsz, id, key)
-    ccall((:flux_job_kvs_key, libflux_core), Cint, (Cstring, Cint, flux_jobid_t, Cstring), buf, bufsz, id, key)
-end
-
-function flux_job_kvs_guest_key(buf, bufsz, id, key)
-    ccall((:flux_job_kvs_guest_key, libflux_core), Cint, (Cstring, Cint, flux_jobid_t, Cstring), buf, bufsz, id, key)
-end
-
-function flux_job_kvs_namespace(buf, bufsz, id)
-    ccall((:flux_job_kvs_namespace, libflux_core), Cint, (Cstring, Cint, flux_jobid_t), buf, bufsz, id)
-end
-
-function flux_job_event_watch(h, id, path, flags)
-    ccall((:flux_job_event_watch, libflux_core), Ptr{flux_future_t}, (Ptr{flux_t}, flux_jobid_t, Cstring, Cint), h, id, path, flags)
-end
-
-function flux_job_event_watch_get(f, event)
-    ccall((:flux_job_event_watch_get, libflux_core), Cint, (Ptr{flux_future_t}, Ptr{Cstring}), f, event)
-end
-
-function flux_job_event_watch_cancel(f)
-    ccall((:flux_job_event_watch_cancel, libflux_core), Cint, (Ptr{flux_future_t},), f)
-end
-
-function MPIR_Breakpoint()
-    ccall((:MPIR_Breakpoint, libflux_core), Cvoid, ())
-end
-
-function get_mpir_being_debugged()
-    ccall((:get_mpir_being_debugged, libflux_core), Cint, ())
-end
-
-function set_mpir_being_debugged(v)
-    ccall((:set_mpir_being_debugged, libflux_core), Cvoid, (Cint,), v)
 end


### PR DESCRIPTION
The binding generation in #1 was fragile since it used the preprocessed headerts for the Python bindings.
Clang.jl was skipping the headers included by `core.h` since the `header_wrapped` lambda skipped the included headers.

