### PR TITLE
Update wrap.jl to use Clang.jl's new generator

### DIFF
--- a/res/prologue.jl
+++ b/res/prologue.jl
@@ -1,0 +1,3 @@
+include(joinpath(@__DIR__, "..", "deps", "deps.jl"))
+
+const pid_t = Cint

--- a/res/wrap.jl
+++ b/res/wrap.jl
@@ -1,4 +1,4 @@
-using Clang
+using Clang.Generators
 
 if length(ARGS) != 1
   error("Pass the path to the Flux headers as the first argument")
@@ -8,25 +8,15 @@ header_dir = ARGS[1]
 isdir(header_dir) || error("$header_dir does not exist")
 
 const FLUX_INCLUDE = normpath(header_dir)
+const FLUX_DIR = joinpath(FLUX_INCLUDE, "flux")
+const FLUX_HEADERS = [joinpath(FLUX_DIR, header) for header in readdir(FLUX_DIR)]
 
-headers = ["flux/core.h"]
-FLUX_HEADERS = map(h->joinpath(FLUX_INCLUDE,h), headers)
+args = ["-I$FLUX_INCLUDE"]
 
-# To inlude all of the headers included by `core.h`
-function wrapped(root, current)
-  if dirname(current) == joinpath(FLUX_INCLUDE, "flux", "core")
-    return true
-  end
-  return root == current
-end
+options = load_options(joinpath(@__DIR__, "wrap.toml"))
 
-wc = init(; headers = FLUX_HEADERS,
-            output_file = "libflux_h.jl",
-            common_file = "libflux_common.jl",
-            clang_includes = [FLUX_INCLUDE, CLANG_INCLUDE],
-            clang_args = ["-I", FLUX_INCLUDE],
-            header_wrapped = wrapped,
-            header_library = x->"libflux_core",
-            )
+@add_def pid_t
 
-run(wc)
+ctx = create_context(FLUX_HEADERS, args, options)
+
+build!(ctx)

--- a/res/wrap.toml
+++ b/res/wrap.toml
@@ -1,0 +1,8 @@
+[general]
+library_name = "libflux_core"
+output_file_path = "../src/api.jl"
+module_name = "API"
+prologue_file_path = "./prologue.jl"
+
+[codegen.macro]
+macro_mode = "basic"


### PR DESCRIPTION
This PR only updates the generator script, bindings are not regenerated.