### PR TITLE
Add parsing for JSON JobSpec according to Schema

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,7 +6,9 @@ version = "0.1.0"
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
 JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+StructTypes = "856f2bd8-1eba-4b0a-8007-ebc267875bd4"
 
 [compat]
 CEnum = "0.4"
 JSON3 = "1.7"
+StructTypes = "1.5"

--- a/src/FluxRM.jl
+++ b/src/FluxRM.jl
@@ -69,5 +69,6 @@ end
 
 include("core/future.jl")
 include("core/kvs.jl")
+include("jobspec.jl")
 
 end # module

--- a/src/jobspec.jl
+++ b/src/jobspec.jl
@@ -20,14 +20,26 @@ StructTypes.StructType(::Type{GPU}) = StructTypes.Mutable()
 StructTypes.omitempties(::Type{GPU}) = (:unit,)
 GPU(count, unit=nothing) = GPU("gpu", count, unit)
 
+function validate(gpu::GPU, version)
+    @assert gpu.type == "gpu"
+    @assert gpu.count >= 1
+    return true
+end
+
 Base.@kwdef mutable struct CPUCore <: IntraNodeResource 
-    type::String = "cpu"
+    type::String = "core"
     count::Int = 1
     unit::Union{Nothing, String} = nothing
 end
 StructTypes.StructType(::Type{CPUCore}) = StructTypes.Mutable()
 StructTypes.omitempties(::Type{CPUCore}) = (:unit,)
 CPUCore(count, unit=nothing) = CPUCore("core", count, unit)
+
+function validate(cpu::CPUCore, version)
+    @assert cpu.type == "core"
+    @assert cpu.count >= 1
+    return true
+end
 
 StructTypes.subtypekey(::Type{IntraNodeResource}) = :type
 StructTypes.subtypes(::Type{IntraNodeResource}) = (core=CPUCore, gpu=GPU)
@@ -50,6 +62,13 @@ end
 StructTypes.StructType(::Type{Slot}) = StructTypes.Mutable()
 StructTypes.omitempties(::Type{Slot}) = (:exclusive, :unit)
 
+function validate(slot::Slot, version)
+    @assert slot.type == "slot"
+    @assert slot.count >= 1
+    @assert 1 <= length(slot.with) <= 2
+    return all(x->validate(x, version), slot.with)
+end
+
 Base.@kwdef mutable struct Node <: Resource
     type::String = "node"
     count::Int = 1
@@ -58,6 +77,14 @@ Base.@kwdef mutable struct Node <: Resource
 end
 StructTypes.StructType(::Type{Node}) = StructTypes.Mutable()
 StructTypes.omitempties(::Type{Node}) = (:unit,)
+
+function validate(node::Node, version)
+    @assert node.type == "node"
+    @assert node.count >= 1
+    @assert length(node.with) == 1
+    return all(x->validate(x, version), node.with)
+end
+
 
 StructTypes.subtypekey(::Type{Resource}) = :type
 StructTypes.subtypes(::Type{Resource}) = (node=Node, slot=Slot)
@@ -72,12 +99,30 @@ end
 StructTypes.StructType(::Type{Count}) = StructTypes.Mutable()
 StructTypes.omitempties(::Type{Count}) = (:per_slot, :total)
 
+function validate(count::Count, version)
+    per_slot = count.per_slot
+    total = count.total
+    if per_slot !== nothing
+        @assert per_slot >= 1
+    end
+    if total !== nothing
+        @assert total >= 1
+    end
+    return true
+end
+
 struct Task
     command::Vector{String}
     slot::String
     count::Count
 end
 StructTypes.StructType(::Type{Task}) = StructTypes.Struct()
+
+function validate(task::Task, version)
+    @assert length(task.command) > 0
+    @assert !isempty(task.slot)
+    return validate(task.count, version)
+end
 
 ###
 # Attributes
@@ -90,12 +135,21 @@ end
 StructTypes.StructType(::Type{System}) = StructTypes.Mutable()
 StructTypes.omitempties(::Type{System}) = (:cwd, :environment)
 
+function validate(system::System, version)
+    @assert system.duration >= 0
+    return true
+end
+
 Base.@kwdef mutable struct Attributes
     system::System = System() # mandatory
     user::Union{Nothing, Dict} = nothing
 end
 StructTypes.StructType(::Type{Attributes}) = StructTypes.Mutable()
 StructTypes.omitempties(::Type{Attributes}) = (:user,)
+
+function validate(attr::Attributes, version)
+    return validate(attr.system, version)
+end
 
 ###
 # JobSpec
@@ -109,5 +163,15 @@ struct Jobspec
 end
 StructTypes.StructType(::Type{Jobspec}) = StructTypes.Struct()
 JobspecV1(resources, tasks, attributes) = Jobspec(1, resources, tasks, attributes)
+
+function validate(jobspec::Jobspec, version)
+    @assert jobspec.version == version
+    @assert length(jobspec.resources) == 1
+    @assert length(jobspec.tasks) <= 1
+    isvalid = validate(jobspec.attributes, version)
+    isvalid &= all(t->validate(t, version), jobspec.tasks)
+    isvalid &= all(r->validate(r, version), jobspec.resources)
+    return isvalid
+end
 
 end # module

--- a/src/jobspec.jl
+++ b/src/jobspec.jl
@@ -1,0 +1,113 @@
+module JobSpec
+
+export GPU, CPUCore, Slot, Node, Task, Count, System, Attributes, Jobspec, JobspecV1
+
+using StructTypes
+
+###
+# IntraNodeResource
+###
+
+abstract type IntraNodeResource end
+StructTypes.StructType(::Type{IntraNodeResource}) = StructTypes.AbstractType()
+
+Base.@kwdef mutable struct GPU <: IntraNodeResource 
+    type::String = "gpu"
+    count::Int = 1
+    unit::Union{Nothing, String} = nothing
+end
+StructTypes.StructType(::Type{GPU}) = StructTypes.Mutable()
+StructTypes.omitempties(::Type{GPU}) = (:unit,)
+GPU(count, unit=nothing) = GPU("gpu", count, unit)
+
+Base.@kwdef mutable struct CPUCore <: IntraNodeResource 
+    type::String = "cpu"
+    count::Int = 1
+    unit::Union{Nothing, String} = nothing
+end
+StructTypes.StructType(::Type{CPUCore}) = StructTypes.Mutable()
+StructTypes.omitempties(::Type{CPUCore}) = (:unit,)
+CPUCore(count, unit=nothing) = CPUCore("core", count, unit)
+
+StructTypes.subtypekey(::Type{IntraNodeResource}) = :type
+StructTypes.subtypes(::Type{IntraNodeResource}) = (core=CPUCore, gpu=GPU)
+
+###
+# Resource
+###
+
+abstract type Resource end
+StructTypes.StructType(::Type{Resource}) = StructTypes.AbstractType()
+
+Base.@kwdef mutable struct Slot <: Resource
+    type::String = "slot"
+    count::Int = 1
+    label::String = ""
+    with::Vector{IntraNodeResource} = IntraNodeResource[]
+    exclusive::Union{Nothing, Bool} = nothing
+    unit::Union{Nothing, String} =  nothing
+end
+StructTypes.StructType(::Type{Slot}) = StructTypes.Mutable()
+StructTypes.omitempties(::Type{Slot}) = (:exclusive, :unit)
+
+Base.@kwdef mutable struct Node <: Resource
+    type::String = "node"
+    count::Int = 1
+    with::Vector{Slot} = Slot[]
+    unit::Union{Nothing, String} = nothing
+end
+StructTypes.StructType(::Type{Node}) = StructTypes.Mutable()
+StructTypes.omitempties(::Type{Node}) = (:unit,)
+
+StructTypes.subtypekey(::Type{Resource}) = :type
+StructTypes.subtypes(::Type{Resource}) = (node=Node, slot=Slot)
+
+###
+# Tasks
+###
+Base.@kwdef mutable struct Count
+    per_slot::Union{Nothing, Int} = nothing
+    total::Union{Nothing, Int} = nothing
+end
+StructTypes.StructType(::Type{Count}) = StructTypes.Mutable()
+StructTypes.omitempties(::Type{Count}) = (:per_slot, :total)
+
+struct Task
+    command::Vector{String}
+    slot::String
+    count::Count
+end
+StructTypes.StructType(::Type{Task}) = StructTypes.Struct()
+
+###
+# Attributes
+###
+Base.@kwdef mutable struct System
+    duration::Real = 0 # mandatory
+    cwd::Union{Nothing, String} = nothing
+    environment::Union{Nothing, Dict} = nothing
+end
+StructTypes.StructType(::Type{System}) = StructTypes.Mutable()
+StructTypes.omitempties(::Type{System}) = (:cwd, :environment)
+
+Base.@kwdef mutable struct Attributes
+    system::System = System() # mandatory
+    user::Union{Nothing, Dict} = nothing
+end
+StructTypes.StructType(::Type{Attributes}) = StructTypes.Mutable()
+StructTypes.omitempties(::Type{Attributes}) = (:user,)
+
+###
+# JobSpec
+###
+
+struct Jobspec
+    version::Int
+    resources::Vector{Resource}
+    tasks::Vector{Task}
+    attributes::Attributes
+end
+StructTypes.StructType(::Type{Jobspec}) = StructTypes.Struct()
+JobspecV1(resources, tasks, attributes) = Jobspec(1, resources, tasks, attributes)
+
+end # module

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,3 +1,4 @@
 [deps]
 FluxRM = "e7b9fac9-e441-4388-a71b-956020f2d1a2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"

--- a/test/jobspec.jl
+++ b/test/jobspec.jl
@@ -2,19 +2,25 @@ using FluxRM.JobSpec
 using JSON3
 using Test
 
+import FluxRM.JobSpec: validate
+
 roundtrip(x::T) where T = JSON3.read(JSON3.write(x), T)
 
 @testset "JSON" begin
     @testset "IntraNodeResource" begin
         gpu = roundtrip(GPU(5))
+        @test validate(gpu, 1)
         @test gpu.count == 5
+
         core = roundtrip(CPUCore(5))
+        @test validate(core, 1)
         @test core.count == 5
     end
 
     @testset "Resources" begin
         slot = Slot(label="slot", count=5, exclusive=true, with=[CPUCore(16)])
         slot = roundtrip(slot)
+        @test validate(slot, 1)
         @test slot.exclusive == true
         @test slot.label == "slot"
         @test slot.count == 5
@@ -25,6 +31,7 @@ roundtrip(x::T) where T = JSON3.read(JSON3.write(x), T)
 
         slot = Slot(label="slot", count=5, with=[CPUCore(16), GPU(1)])
         slot = roundtrip(slot)
+        @test validate(slot, 1)
         @test slot.exclusive === nothing
         @test length(slot.with) == 2
         core = findfirst(r->r.type == "core", slot.with)
@@ -40,6 +47,7 @@ roundtrip(x::T) where T = JSON3.read(JSON3.write(x), T)
 
         node = Node(count = 4, with=[slot])
         node = roundtrip(node)
+        @test validate(node, 1)
         @test node.count == 4
         slot = first(node.with)
         @test slot isa Slot
@@ -48,6 +56,7 @@ roundtrip(x::T) where T = JSON3.read(JSON3.write(x), T)
     @testset "Task" begin
         task = JobSpec.Task(["hostname"], "slot", Count(total=2))
         task = roundtrip(task)
+        @test validate(task, 1)
         @test task.slot == "slot"
         @test task.count.per_slot === nothing
         @test task.count.total == 2
@@ -55,11 +64,13 @@ roundtrip(x::T) where T = JSON3.read(JSON3.write(x), T)
 
     @testset "System" begin
         system = roundtrip(System(duration=3600)) 
+        @test validate(system, 1)
         @test system.duration == 3600
     end
 
     @testset "Attributes" begin
         attr = roundtrip(Attributes(system=System(duration=3600)))
+        @test validate(attr, 1)
         @test attr.system.duration == 3600
     end
 
@@ -68,6 +79,7 @@ roundtrip(x::T) where T = JSON3.read(JSON3.write(x), T)
         task = JobSpec.Task(["hostname"], "slot", Count(total=2))
         jobspec = JobspecV1([slot], [task], Attributes(system=System(duration=3600)))
         jobspec = roundtrip(jobspec)
+        @test validate(jobspec, 1)
 
         jobspec = """
         {
@@ -109,6 +121,7 @@ roundtrip(x::T) where T = JSON3.read(JSON3.write(x), T)
         }
         """
         jobspec = JSON3.read(jobspec, Jobspec)
+        @test validate(jobspec, 1)
         command = first(jobspec.tasks).command
         @test first(command) == "whoami"
         @test first(jobspec.resources) isa Node

--- a/test/jobspec.jl
+++ b/test/jobspec.jl
@@ -1,0 +1,117 @@
+using FluxRM.JobSpec
+using JSON3
+using Test
+
+roundtrip(x::T) where T = JSON3.read(JSON3.write(x), T)
+
+@testset "JSON" begin
+    @testset "IntraNodeResource" begin
+        gpu = roundtrip(GPU(5))
+        @test gpu.count == 5
+        core = roundtrip(CPUCore(5))
+        @test core.count == 5
+    end
+
+    @testset "Resources" begin
+        slot = Slot(label="slot", count=5, exclusive=true, with=[CPUCore(16)])
+        slot = roundtrip(slot)
+        @test slot.exclusive == true
+        @test slot.label == "slot"
+        @test slot.count == 5
+        core = first(slot.with)
+        @test core isa CPUCore
+        @test core.count == 16
+        @test core.type == "core"
+
+        slot = Slot(label="slot", count=5, with=[CPUCore(16), GPU(1)])
+        slot = roundtrip(slot)
+        @test slot.exclusive === nothing
+        @test length(slot.with) == 2
+        core = findfirst(r->r.type == "core", slot.with)
+        gpu = findfirst(r->r.type == "gpu", slot.with)
+        @test core !== nothing
+        @test gpu !== nothing
+        core = slot.with[core]
+        gpu = slot.with[gpu]
+        @test core isa CPUCore
+        @test gpu isa GPU
+        @test core.count == 16
+        @test gpu.count == 1
+
+        node = Node(count = 4, with=[slot])
+        node = roundtrip(node)
+        @test node.count == 4
+        slot = first(node.with)
+        @test slot isa Slot
+    end
+
+    @testset "Task" begin
+        task = JobSpec.Task(["hostname"], "slot", Count(total=2))
+        task = roundtrip(task)
+        @test task.slot == "slot"
+        @test task.count.per_slot === nothing
+        @test task.count.total == 2
+    end
+
+    @testset "System" begin
+        system = roundtrip(System(duration=3600)) 
+        @test system.duration == 3600
+    end
+
+    @testset "Attributes" begin
+        attr = roundtrip(Attributes(system=System(duration=3600)))
+        @test attr.system.duration == 3600
+    end
+
+    @testset "JobSpec" begin
+        slot = Slot(label="slot", count=5, with=[CPUCore(16)])
+        task = JobSpec.Task(["hostname"], "slot", Count(total=2))
+        jobspec = JobspecV1([slot], [task], Attributes(system=System(duration=3600)))
+        jobspec = roundtrip(jobspec)
+
+        jobspec = """
+        {
+            "version": 1,
+            "resources": [
+                {
+                    "type": "node",
+                    "count": 1,
+                    "with": [
+                        {
+                            "type": "slot",
+                            "label": "mylabel",
+                            "count": 4,
+                            "with": [
+                                {
+                                    "type": "core",
+                                    "count": 1
+                                }
+                            ]
+                        }
+                    ]
+
+                }
+            ],
+            "tasks": [
+                {
+                    "command": [ "whoami" ],
+                    "slot": "mylabel",
+                    "count": {
+                        "total": 2
+                    }
+                }
+            ],
+            "attributes": {
+                "system": {
+                    "duration": 3600
+                }
+            }
+        }
+        """
+        jobspec = JSON3.read(jobspec, Jobspec)
+        command = first(jobspec.tasks).command
+        @test first(command) == "whoami"
+        @test first(jobspec.resources) isa Node
+    end
+end
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -43,6 +43,8 @@ end
     end
 end
 
+include("jobspec.jl")
+
 @testset "KVS" begin
     with_flux(1) do flux
         kvs = FluxRM.KVS(flux)


### PR DESCRIPTION
Following https://github.com/flux-framework/flux-core/blob/5b26a1260970eb88941d862695810b15cf48703b/src/modules/job-ingest/schemas/jobspec_v1.jsonschema

@SteVwonder Should I worry about the difference between the Jobspec and JobspecV1 schemas?

cc: @quinnj 